### PR TITLE
Proposed changes for client usage and reducing latency

### DIFF
--- a/NET/ViGEmClient/Targets/Xbox360/Xbox360Report.cs
+++ b/NET/ViGEmClient/Targets/Xbox360/Xbox360Report.cs
@@ -36,17 +36,17 @@ namespace Nefarius.ViGEm.Client.Targets.Xbox360
     {
         public ushort Buttons { get; private set; }
 
-        public byte LeftTrigger { get; private set; }
+        public byte LeftTrigger { get; set; }
 
-        public byte RightTrigger { get; private set; }
+        public byte RightTrigger { get; set; }
 
-        public short LeftThumbX { get; private set; }
+        public short LeftThumbX { get; set; }
 
-        public short LeftThumbY { get; private set; }
+        public short LeftThumbY { get; set; }
 
-        public short RightThumbX { get; private set; }
+        public short RightThumbX { get; set; }
 
-        public short RightThumbY { get; private set; }
+        public short RightThumbY { get; set; }
 
         public void SetButtons(params Xbox360Buttons[] buttons)
         {
@@ -66,6 +66,11 @@ namespace Nefarius.ViGEm.Client.Targets.Xbox360
             {
                 Buttons &= (ushort)~button;
             }
+        }
+
+        public void SetButtons(Xbox360Buttons buttons)
+        {
+            Buttons = (ushort)buttons;
         }
 
         public void SetAxis(Xbox360Axes axis, short value)

--- a/Sys/ViGEmBus/ViGEmBus.vcxproj
+++ b/Sys/ViGEmBus/ViGEmBus.vcxproj
@@ -42,6 +42,7 @@
     <Configuration>Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>ViGEmBus</RootNamespace>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -87,6 +88,7 @@
     <KMDF_VERSION_MAJOR>1</KMDF_VERSION_MAJOR>
     <KMDF_VERSION_MINOR>9</KMDF_VERSION_MINOR>
     <ALLOW_DATE_TIME>1</ALLOW_DATE_TIME>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <TargetVersion>Windows7</TargetVersion>
@@ -243,6 +245,12 @@
     <Link>
       <AdditionalDependencies>$(DDK_LIB_PATH)ntstrsafe.lib;$(DDK_LIB_PATH)wdmsec.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <ClCompile>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+    </ClCompile>
+    <ClCompile>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+    </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <Inf Include="ViGEmBus.inf" />


### PR DESCRIPTION
With the current progress being done with DS4Windows, I have made some changes to portions of ViGEm in order to improve performance. Thank you for already incorporating a couple of the changes that I have proposed. Here are a couple of other changes that are being used by DS4Windows that have been tested as being useful for reducing latency.

The changes to Xbox360Report.cs are used to reduce method calls and skip many switch clause runs. The changes to ViGEmBus.vcxproj have been tested and the changes do help reduce latency further by enabling some optimizations while compiling.